### PR TITLE
Responsified layout for small screens

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -2,17 +2,20 @@
   <div class="app">
     <Sidebar></Sidebar>
     <Map></Map>
+    <ScrollTopButton></ScrollTopButton>
   </div>
 </template>
 
 <script>
 import Sidebar from "@/components/Sidebar";
 import Map from "@/components/Map";
+import ScrollTopButton from "@/components/ScrollTopButton";
 
 export default {
   components: {
     Map,
     Sidebar,
+    ScrollTopButton,
   },
 };
 </script>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -12,8 +12,8 @@ import Map from "@/components/Map";
 export default {
   components: {
     Map,
-    Sidebar
-  }
+    Sidebar,
+  },
 };
 </script>
 
@@ -29,5 +29,14 @@ body {
   text-align: center;
   color: #2c3e50;
   display: flex;
+}
+
+@media (max-width: 800px) {
+  .app {
+    flex-direction: column;
+  }
+  .content {
+    width: 100%;
+  }
 }
 </style>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="app">
     <Sidebar></Sidebar>
-    <Map></Map>
+    <Map class="map"></Map>
     <ScrollTopButton></ScrollTopButton>
   </div>
 </template>
@@ -38,8 +38,10 @@ body {
   .app {
     flex-direction: column;
   }
-  .content {
-    width: 100%;
+  .map {
+    padding: 2em;
+    background-color: white;
+    overflow: hidden;
   }
 }
 </style>

--- a/app/src/components/ScrollTopButton.vue
+++ b/app/src/components/ScrollTopButton.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="fab">
+    <md-button class="md-fab md-primary md-fab-bottom-right" @click="scrollTop">
+      <md-icon>arrow_upward</md-icon>
+    </md-button>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    scrollTop() {
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: "smooth",
+      });
+    },
+  },
+};
+</script>
+
+<style>
+@import url("https://fonts.googleapis.com/css?family=Material+Icons");
+
+.fab {
+  display: none;
+}
+
+@media (max-width: 800px) {
+  .fab {
+    display: block;
+  }
+}
+</style>

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -36,16 +36,8 @@
           </div>
         </md-card-header>
       </md-card>
-      <md-card class="chart-total" md-with-hover>
-        <md-card-header>
-          <ChartTotal />
-        </md-card-header>
-      </md-card>
-      <md-card class="chart-daily-change" md-with-hover>
-        <md-card-header>
-          <ChartChangePrevDay />
-        </md-card-header>
-      </md-card>
+      <ChartTotal class="chart" />
+      <ChartChangePrevDay class="chart" />
       <md-divider></md-divider>
       <span class="md-caption"
         >Quelle:
@@ -109,14 +101,28 @@ export default {
 @media (max-width: 800px) {
   .content {
     width: 100%;
+    height: fit-content;
+    overflow-y: initial;
   }
 }
 
-.chart-total,
-.chart-daily-change,
+.toolbar {
+  position: sticky;
+  position: -webkit-sticky;
+  z-index: 1000;
+  top: 0px;
+}
+
 .card-total,
 .card-percentage {
   margin: 10px;
+}
+
+.chart {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding-right: 10px;
+  padding-left: 10px;
 }
 
 .md-title {

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -36,8 +36,16 @@
           </div>
         </md-card-header>
       </md-card>
-      <ChartTotal></ChartTotal>
-      <ChartChangePrevDay></ChartChangePrevDay>
+      <md-card class="chart-total" md-with-hover>
+        <md-card-header>
+          <ChartTotal />
+        </md-card-header>
+      </md-card>
+      <md-card class="chart-daily-change" md-with-hover>
+        <md-card-header>
+          <ChartChangePrevDay />
+        </md-card-header>
+      </md-card>
       <md-divider></md-divider>
       <span class="md-caption"
         >Quelle:
@@ -67,26 +75,26 @@ export default {
   name: "Sidebar",
   components: {
     ChartTotal,
-    ChartChangePrevDay
+    ChartChangePrevDay,
   },
   computed: {
     ...mapGetters(["lastStats", "lastDay"]),
-    ...mapState(["state"])
+    ...mapState(["state"]),
   },
   filters: {
     day(date) {
       return new Intl.DateTimeFormat("de-DE", {
         day: "2-digit",
         month: "2-digit",
-        year: "numeric"
+        year: "numeric",
       }).format(new Date(date));
     },
     number(number) {
       return new Intl.NumberFormat("de-DE", { useGrouping: true }).format(
         number
       );
-    }
-  }
+    },
+  },
 };
 </script>
 
@@ -98,6 +106,14 @@ export default {
   overflow-y: scroll;
 }
 
+@media (max-width: 800px) {
+  .content {
+    width: 100%;
+  }
+}
+
+.chart-total,
+.chart-daily-change,
 .card-total,
 .card-percentage {
   margin: 10px;


### PR DESCRIPTION
Moves the map component below the charts to make it accessible on small screens and the sidebar fills the whole width. Maybe needs a little more refinement. Perhaps it would be good to restrict the height of the map in order to scroll on a touchscreen.
For now I added a FAB to scroll back to the top.